### PR TITLE
Kit::Admin

### DIFF
--- a/domains/kit-auth/app/admin/kit/auth/admin.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin.rb
@@ -1,0 +1,2 @@
+module Kit::Auth::Admin
+end

--- a/domains/kit-auth/app/admin/kit/auth/admin/application.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/application.rb
@@ -1,6 +1,7 @@
 module Kit::Auth::Admin::Application
 end
 
+=begin
 Kit::Auth::Admin.register Kit::Auth::Models::Read::Application, as: 'Application', namespace: :kit_auth_admin do
   menu label: 'OAuthApplication', parent: 'OAuth'
 
@@ -27,3 +28,4 @@ Kit::Auth::Admin.register Kit::Auth::Models::Read::Application, as: 'Application
   end
 
 end
+=end

--- a/domains/kit-auth/app/admin/kit/auth/admin/application.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/application.rb
@@ -1,9 +1,8 @@
 module Kit::Auth::Admin::Application
 end
 
-=begin
-Kit::Auth::Admin.register Kit::Auth::Models::Read::Application, as: 'Application', namespace: :kit_auth_admin do
-  menu label: 'OAuthApplication', parent: 'OAuth'
+ActiveAdmin.register Kit::Auth::Models::Read::Application, as: 'Application', namespace: :kit_auth do
+  menu label: 'Application', parent: 'Auth'
 
   actions :all, except: [:new, :edit, :destroy]
 
@@ -18,14 +17,9 @@ Kit::Auth::Admin.register Kit::Auth::Models::Read::Application, as: 'Application
 
     columns do
       column do
-        Kit::Auth::Admin::Tables::OauthAccessGrant.new(self).panel_list resource.oauth_access_grants
-      end
-
-      column do
-        Kit::Auth::Admin::Tables::OauthAccessToken.new(self).panel_list resource.access_tokens
+        Kit::Auth::Admin::Tables::UserSecret.new(self).panel_list resource.user_access_tokens, attrs_except: [:application]
       end
     end
   end
 
 end
-=end

--- a/domains/kit-auth/app/admin/kit/auth/admin/oauth_identity.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/oauth_identity.rb
@@ -1,6 +1,7 @@
 module Kit::Auth::Admin::OauthIdentity
 end
 
+=begin
 Kit::Auth::Admin.register Kit::Auth::Models::Read::OauthIdentity, as: 'OauthIdentity', namespace: :kit_auth_admin do
   menu label: 'OAuthIdentity', parent: 'OAuth'
 
@@ -15,3 +16,4 @@ Kit::Auth::Admin.register Kit::Auth::Models::Read::OauthIdentity, as: 'OauthIden
   end
 
 end
+=end

--- a/domains/kit-auth/app/admin/kit/auth/admin/oauth_identity.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/oauth_identity.rb
@@ -1,9 +1,8 @@
 module Kit::Auth::Admin::OauthIdentity
 end
 
-=begin
-Kit::Auth::Admin.register Kit::Auth::Models::Read::OauthIdentity, as: 'OauthIdentity', namespace: :kit_auth_admin do
-  menu label: 'OAuthIdentity', parent: 'OAuth'
+ActiveAdmin.register Kit::Auth::Models::Read::OauthIdentity, as: 'OauthIdentity', namespace: :kit_auth do
+  menu label: 'OAuthIdentity', parent: 'Auth'
 
   actions :all, except: [:new, :edit, :destroy]
 
@@ -16,4 +15,3 @@ Kit::Auth::Admin.register Kit::Auth::Models::Read::OauthIdentity, as: 'OauthIden
   end
 
 end
-=end

--- a/domains/kit-auth/app/admin/kit/auth/admin/request_metadata.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/request_metadata.rb
@@ -3,6 +3,7 @@ require 'browser'
 module Kit::Auth::Admin::RequestMetadata
 end
 
+=begin
 ActiveAdmin.register Kit::Auth::Models::Write::RequestMetadata, as: 'RequestMetadata', namespace: :kit_auth_admin do
   menu parent: 'Users'
 
@@ -39,3 +40,4 @@ ActiveAdmin.register Kit::Auth::Models::Write::RequestMetadata, as: 'RequestMeta
   end
 
 end
+=end

--- a/domains/kit-auth/app/admin/kit/auth/admin/request_metadata.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/request_metadata.rb
@@ -3,11 +3,16 @@ require 'browser'
 module Kit::Auth::Admin::RequestMetadata
 end
 
-=begin
-ActiveAdmin.register Kit::Auth::Models::Write::RequestMetadata, as: 'RequestMetadata', namespace: :kit_auth_admin do
-  menu parent: 'Users'
+ActiveAdmin.register Kit::Auth::Models::Write::RequestMetadata, as: 'RequestMetadata', namespace: :kit_auth do
+  menu parent: 'Logs'
 
   actions :all, except: [:new, :edit, :destroy]
+
+  controller do
+    def scoped_collection
+      super.preload(:user)
+    end
+  end
 
   index do
     Kit::Auth::Admin::Tables::RequestMetadata.new(self).index
@@ -40,4 +45,3 @@ ActiveAdmin.register Kit::Auth::Models::Write::RequestMetadata, as: 'RequestMeta
   end
 
 end
-=end

--- a/domains/kit-auth/app/admin/kit/auth/admin/tables/application.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/tables/application.rb
@@ -8,8 +8,6 @@ class Kit::Auth::Admin::Tables::Application < Kit::Auth::Admin::Tables::BaseTabl
       created_at:   nil,
       updated_at:   nil,
       uid:          :code,
-      secret:       :code,
-      redirect_uri: :code,
       scopes:       :code,
       confidential: nil,
     )

--- a/domains/kit-auth/app/admin/kit/auth/admin/tables/user_secret.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/tables/user_secret.rb
@@ -4,22 +4,20 @@ class Kit::Auth::Admin::Tables::UserSecret < Kit::Auth::Admin::Tables::BaseTable
 
   def attributes_for_all
     base_attributes.merge(
-      created_at:    nil,
-      updated_at:    nil,
-      user:          :model_verbose,
-      application:   :model_verbose,
-      token:         :code,
-      active:        [nil, ->(el) { el.active? }],
-      refresh_token: :code,
-      expires_in:    :code,
-      scopes:        :code,
-      revoked_at:    nil,
-      last_urm:      [:model, ->(el) { el.last_request_metadata }],
+      created_at:  nil,
+      updated_at:  nil,
+      user:        :model_verbose,
+      application: :model_verbose,
+      secret:      :code,
+      active:      [nil, ->(el) { el.active? }],
+      expires_in:  :code,
+      scopes:      :code,
+      revoked_at:  nil,
     )
   end
 
   def attributes_for_index
-    attributes_for_all.slice(:id, :created_at, :user, :application, :token, :active, :expires_in, :revoked_at, :scopes, :last_urm)
+    attributes_for_all.slice(:id, :created_at, :user, :active, :scopes, :application, :expires_in, :revoked_at)
   end
 
   def attributes_for_list

--- a/domains/kit-auth/app/admin/kit/auth/admin/user.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/user.rb
@@ -1,7 +1,7 @@
 module Kit::Auth::Admin::User
 end
 
-ActiveAdmin.register Kit::Auth::Models::Write::User, as: 'User', namespace: :kit_auth_admin do
+ActiveAdmin.register Kit::Auth::Models::Write::User, as: 'User', namespace: :kit_auth do
   menu label: 'Users'
 
   actions :all, except: [:new, :edit, :destroy]

--- a/domains/kit-auth/app/admin/kit/auth/admin/user_secret.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/user_secret.rb
@@ -1,11 +1,16 @@
 module Kit::Auth::Admin::UserSecret
 end
 
-=begin
-Kit::Auth::Admin.register Kit::Auth::Models::Read::UserSecret, as: 'UserSecret', namespace: :kit_auth_admin do
-  menu label: 'OAuthAccessToken', parent: 'OAuth'
+ActiveAdmin.register Kit::Auth::Models::Read::UserSecret, as: 'UserSecret', namespace: :kit_auth do
+  menu label: 'UserSecrets', parent: 'Users'
 
   actions :all, except: [:new, :edit, :destroy]
+
+  controller do
+    def scoped_collection
+      super.preload(:application, :user)
+    end
+  end
 
   index do
     Kit::Auth::Admin::Tables::UserSecret.new(self).index
@@ -18,7 +23,7 @@ Kit::Auth::Admin.register Kit::Auth::Models::Read::UserSecret, as: 'UserSecret',
 
     columns do
       column do
-        Kit::Auth::Admin::Tables::User.new(self).panel resource.user_id
+        Kit::Auth::Admin::Tables::User.new(self).panel resource.user
       end
 
       column do
@@ -28,4 +33,3 @@ Kit::Auth::Admin.register Kit::Auth::Models::Read::UserSecret, as: 'UserSecret',
   end
 
 end
-=end

--- a/domains/kit-auth/app/admin/kit/auth/admin/user_secret.rb
+++ b/domains/kit-auth/app/admin/kit/auth/admin/user_secret.rb
@@ -1,6 +1,7 @@
 module Kit::Auth::Admin::UserSecret
 end
 
+=begin
 Kit::Auth::Admin.register Kit::Auth::Models::Read::UserSecret, as: 'UserSecret', namespace: :kit_auth_admin do
   menu label: 'OAuthAccessToken', parent: 'OAuth'
 
@@ -27,3 +28,4 @@ Kit::Auth::Admin.register Kit::Auth::Models::Read::UserSecret, as: 'UserSecret',
   end
 
 end
+=end

--- a/domains/kit-auth/config/initializers/admin.rb
+++ b/domains/kit-auth/config/initializers/admin.rb
@@ -83,6 +83,10 @@ if defined?(::ActiveAdmin)
     # config.order_clause = MyOrderClause
   end
 
+  ActiveAdmin::BaseController.class_eval do
+    include Kit::Auth::Controllers::Web::Concerns::RailsCurrentUser
+  end
+
 end
 
 module Kit::Auth::Admin # rubocop:disable Style/Documentation

--- a/domains/kit-auth/config/initializers/admin.rb
+++ b/domains/kit-auth/config/initializers/admin.rb
@@ -1,106 +1,34 @@
 if defined?(::ActiveAdmin)
 
   ::ActiveAdmin.setup do |config|
-    #config.site_title = "Admin"
-    # config.site_title_link = "/"
-    # config.site_title_image = "logo.png"
-    # config.favicon = 'favicon.ico'
-
-    config.namespace :kit_auth_admin do |admin|
-      admin.site_title = 'KitAuth - Admin'
+    config.namespace :kit_auth do |admin|
+      #admin.site_title = 'KitAuth - Admin'
       #admin.site_title_link = kit_admin.root_path
       #admin.authentication_method = :authenticate_user
-      admin.authentication_method = false
-      admin.current_user_method = :session_user
+      #admin.authentication_method = false
+      #admin.current_user_method = :session_user
 
-      admin.scope_path       = 'admin'
-      admin.scope_module     = 'admin'
+      admin.scope_as         = 'kit_auth'
+      admin.scope_path       = 'kit_auth'
+      admin.scope_module     = 'kit/auth/admin'
 
       admin.controllers_path = 'Kit::Auth::Admin'
-      admin.url_helpers      = Kit::Auth::Routes
 
-      admin.comments = false
+      admin.comments      = false
       admin.comments_menu = false
+
       #admin.logout_link_path = Kit::Auth::Routes.web_signout_path
-      admin.logout_link_path = '/kit-auth/web/signout'
-      admin.logout_link_method = :delete
+      #admin.logout_link_path   = '/kit-auth/web/signout'
+      #admin.logout_link_method = :delete
 
       admin.root_to = 'users#index'
     end
-
-    config.display_name_methods = [:model_verbose_name]
-
-    # config.authorization_adapter = ActiveAdmin::CanCanAdapter
-    # config.pundit_default_policy = "MyDefaultPunditPolicy"
-    # config.pundit_policy_namespace = :admin
-    # config.cancan_ability_class = "Ability"
-    # config.on_unauthorized_access = :access_denied
-
-    # config.current_user_method = :current_admin_user
-
-    # config.logout_link_path = :destroy_admin_user_session_path
-    # config.logout_link_method = :get
-
-    # config.root_to = 'dashboard#index'
-
-    config.comments = false
-    # config.comments_registration_name = 'AdminComment'
-    # config.comments_order = 'created_at ASC'
-    config.comments_menu = false
-    # config.comments_menu = { parent: 'Admin', priority: 1 }
-
-    config.batch_actions = false
-
-    # config.before_action :do_something_awesome
-    config.filter_attributes = [:hashed_secret, :password, :password_confirmation]
-
-    config.localize_format = :long
-
-    # == Meta Tags
-    #   config.meta_tags = { author: 'My Company' }
-    #   config.meta_tags_for_logged_out_pages = {}
-
-    # config.breadcrumb = false
-
-    # config.create_another = true
-
-    #   config.register_stylesheet 'my_stylesheet.css'
-    #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
-    #   config.register_javascript 'my_javascript.js'
-
-    # config.csv_options = { col_sep: ';' }
-    # config.csv_options = { force_quotes: true }
-
-    # config.default_per_page = 30
-    # config.max_per_page = 10_000
-
-    # config.filters = true
-    config.include_default_association_filters = false
-
-    # config.head = ''.html_safe
-    # config.footer = 'my custom footer text'
-
-    # config.order_clause = MyOrderClause
   end
 
   ActiveAdmin::BaseController.class_eval do
     include Kit::Auth::Controllers::Web::Concerns::RailsCurrentUser
-  end
 
-end
-
-module Kit::Auth::Admin # rubocop:disable Style/Documentation
-
-  def self.register(*args)
-    if defined?(::ActiveAdmin)
-      ActiveAdmin.register(*args)
-    end
-  end
-
-  def self.routes(*args)
-    if defined?(::ActiveAdmin)
-      ActiveAdmin.routes(*args)
-    end
+    helper ActiveAdmin::ViewsHelper
   end
 
 end

--- a/domains/kit-auth/config/routes.rb
+++ b/domains/kit-auth/config/routes.rb
@@ -1,11 +1,4 @@
+# Engine routes: empty!
+# The responsability to mount domain routes belongs to the application container.
 Kit::Auth::Engine.routes.draw do
-
-  Kit::Auth::Admin.routes(self)
-
-  #use_doorkeeper
-
-  #Rails.application.routes.draw do
-  #  use_doorkeeper # scope: 'api/v1/oauth'
-  #end
-
 end

--- a/domains/kit-auth/lib/kit/auth/engine.rb
+++ b/domains/kit-auth/lib/kit/auth/engine.rb
@@ -7,13 +7,13 @@ class Kit::Auth::Engine < ::Rails::Engine
   ::Kit::Engine.config_engine(
     context:   self,
     namespace: Kit::Auth,
-    file:      __FILE__,
+    path:      __dir__,
   )
 
   ::Kit::Domain.config_domain(
     context:   self,
     namespace: Kit::Auth,
-    file:      __FILE__,
+    path:      __dir__,
   )
 
   initializer 'kit-auth.view_helpers' do

--- a/domains/kit-auth/spec/dummy/config/initializers/admin.rb
+++ b/domains/kit-auth/spec/dummy/config/initializers/admin.rb
@@ -1,0 +1,73 @@
+if defined?(::ActiveAdmin)
+
+  ::ActiveAdmin.setup do |config|
+
+  ::ActiveAdmin.setup do |config|
+    config.namespace :kit_auth do |admin|
+      admin.route_prefix = 'admin'
+    end
+   end
+
+    #config.site_title = "Admin"
+    # config.site_title_link = "/"
+    # config.site_title_image = "logo.png"
+    # config.favicon = 'favicon.ico'
+
+    config.display_name_methods = [:model_verbose_name]
+
+    #config.root_prefix = 'admin'
+
+    # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+    # config.pundit_default_policy = "MyDefaultPunditPolicy"
+    # config.pundit_policy_namespace = :admin
+    # config.cancan_ability_class = "Ability"
+    # config.on_unauthorized_access = :access_denied
+
+    # config.current_user_method = :current_admin_user
+
+    # config.logout_link_path = :destroy_admin_user_session_path
+    # config.logout_link_method = :get
+
+    # config.root_to = 'dashboard#index'
+
+    config.comments = false
+    # config.comments_registration_name = 'AdminComment'
+    # config.comments_order = 'created_at ASC'
+    config.comments_menu = false
+    # config.comments_menu = { parent: 'Admin', priority: 1 }
+
+    config.batch_actions = false
+
+    # config.before_action :do_something_awesome
+    config.filter_attributes = [:hashed_secret, :password, :password_confirmation]
+
+    config.localize_format = :long
+
+    # == Meta Tags
+    #   config.meta_tags = { author: 'My Company' }
+    #   config.meta_tags_for_logged_out_pages = {}
+
+    # config.breadcrumb = false
+
+    # config.create_another = true
+
+    #   config.register_stylesheet 'my_stylesheet.css'
+    #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+    #   config.register_javascript 'my_javascript.js'
+
+    # config.csv_options = { col_sep: ';' }
+    # config.csv_options = { force_quotes: true }
+
+    # config.default_per_page = 30
+    # config.max_per_page = 10_000
+
+    # config.filters = true
+    config.include_default_association_filters = false
+
+    # config.head = ''.html_safe
+    # config.footer = 'my custom footer text'
+
+    # config.order_clause = MyOrderClause
+  end
+
+end

--- a/domains/kit-auth/spec/dummy/config/routes.rb
+++ b/domains/kit-auth/spec/dummy/config/routes.rb
@@ -3,8 +3,12 @@
 Rails.application.routes.draw do
 
   Kit::Router::Services::Router.finalize_endpoints
-  #mount Kit::Auth::Engine => "/kit-auth", as: 'kit_auth'
+
+  mount Kit::Auth::Engine => '/'
+
   #mount Sidekiq::Web => '/sidekiq'
+
+  #Kit::Auth::Admin.routes(self)
 
   rails_endpoint_wrapper = ::Kit::Auth::DummyAppContainer::Controllers::WebController
 

--- a/domains/kit-auth/spec/dummy/config/routes.rb
+++ b/domains/kit-auth/spec/dummy/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
 
   #mount Sidekiq::Web => '/sidekiq'
 
-  #Kit::Auth::Admin.routes(self)
+  scope path: 'admin', as: 'admin' do
+    ActiveAdmin.routes(self)
+  end
 
   rails_endpoint_wrapper = ::Kit::Auth::DummyAppContainer::Controllers::WebController
 

--- a/libraries/kit-active_admin/app/helpers/active_admin/views_helper.rb
+++ b/libraries/kit-active_admin/app/helpers/active_admin/views_helper.rb
@@ -1,0 +1,17 @@
+module ActiveAdmin::ViewsHelper
+
+  # Make sure `link_to` calls `main_app.url_for` instead of `url_for`
+  def link_to(name = nil, options = nil, html_options = nil, &block)
+    html_options, options, name = options, name, block if block_given?
+    options ||= {}
+
+    html_options = convert_options_to_data_attributes(options, html_options)
+
+    # NOTE: only change is the following line
+    url = main_app.url_for(options)
+    html_options["href"] ||= url
+
+    content_tag("a", name || url, html_options, &block)
+  end
+
+end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides.rb
@@ -3,9 +3,8 @@ require 'active_admin'
 require_relative "overrides/engines/application"
 require_relative "overrides/engines/extend_namespace_settings"
 require_relative "overrides/engines/extend_router"
-require_relative "overrides/engines/namespace"
 require_relative "overrides/engines/resource_controllers"
-require_relative "overrides/engines/route_builder"
+require_relative "overrides/engines/routes_helpers"
 
 require_relative "overrides/display/auto_link_helper"
 require_relative "overrides/display/display_helper"

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/display/auto_link_helper.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/display/auto_link_helper.rb
@@ -5,7 +5,7 @@ module ActiveAdmin
       def active_admin_resource_for(klass)
         resource = nil
 
-        if respond_to? :active_admin_namespace
+        if klass != NilClass && respond_to?(:active_admin_namespace)
           resource = active_admin_namespace.resource_for klass
 
           if !resource

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/application.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/application.rb
@@ -1,30 +1,37 @@
-module ActiveAdmin
-  class Application
+class ActiveAdmin::Application
 
-    def load!
-      unless loaded?
-        ActiveSupport::Notifications.publish BeforeLoadEvent, self # before_load hook
-        files.each { |file| load file }                            # load files
-        #namespace(default_namespace)                               # init AA resources
-        ActiveSupport::Notifications.publish AfterLoadEvent, self  # after_load hook
-        @@loaded = true
-      end
+  # Prevent the loading of the default namsepace.
+  #
+  # ### References
+  # - https://github.com/activeadmin/activeadmin/blob/v2.9.0/lib/active_admin/application.rb#L116
+  def load!
+    unless loaded?
+      ActiveSupport::Notifications.publish BeforeLoadEvent, self # before_load hook
+      files.each { |file| load file }                            # load files
+      # NOTE: the change is the next commented line.
+      #namespace(default_namespace)                               # init AA resources
+      ActiveSupport::Notifications.publish AfterLoadEvent, self  # after_load hook
+      @@loaded = true
     end
-
-    def routes(rails_router, list = {})
-      load!
-
-      namespaces_tmp = namespaces
-
-      if !list.empty?
-        namespaces_tmp = namespaces_tmp
-          .instance_variable_get(:@namespaces)
-          .slice(*list)
-          .values
-      end
-
-      Router.new(router: rails_router, namespaces: namespaces_tmp).apply
-    end
-
   end
+
+  # Allow to select what admin namespaces to mount.
+  #
+  # ### References
+  # - https://github.com/activeadmin/activeadmin/blob/v2.9.0/lib/active_admin/application.rb#L140
+  def routes(rails_router, list = {})
+    load!
+
+    namespaces_tmp = namespaces
+
+    if !list.empty?
+      namespaces_tmp = namespaces_tmp
+        .instance_variable_get(:@namespaces)
+        .slice(*list)
+        .values
+    end
+
+    ::ActiveAdmin::Router.new(router: rails_router, namespaces: namespaces_tmp).apply
+  end
+
 end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/extend_namespace_settings.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/extend_namespace_settings.rb
@@ -1,6 +1,12 @@
-ActiveAdmin::NamespaceSettings.register :scope_path,       nil
+# Sent to Rails router `scope` when mounting.
+ActiveAdmin::NamespaceSettings.register :scope_as,         nil
 ActiveAdmin::NamespaceSettings.register :scope_module,     nil
+ActiveAdmin::NamespaceSettings.register :scope_path,       nil
 
+# If the admins are mounted in a namespace now known by ActiveAdmin, the routes helper prefix needs to be set.
+ActiveAdmin::NamespaceSettings.register :route_prefix,     nil
+
+# The namespace admin classes live in.
 ActiveAdmin::NamespaceSettings.register :controllers_path, nil
 
-ActiveAdmin::NamespaceSettings.register :url_helpers,      nil
+#ActiveAdmin::NamespaceSettings.register :url_helpers,      nil

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/extend_router.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/extend_router.rb
@@ -4,14 +4,31 @@ class ActiveAdmin::Router
 
   def define_namespace(config)
     options = config.namespace.route_options.dup
-    options.merge!({
+   options.merge!({
       as:     config.namespace.scope_module,
       path:   config.namespace.scope_path,
       module: config.namespace.scope_module,
     })
-    router.scope options do
-      define_routes(config)
+
+    puts "DEFINE NAMESPACE - #{ config.namespace }"
+
+=begin
+    router.namespace module: 'admin', path: 'kit_admin', as: 'kit_auth_admin' do
+      router.scope module: 'auth' do
+        router.scope module: 'admin' do
+          define_routes(config)
+        end
+      end
     end
+=end
+
+    router.scope module: 'admin', path: 'kit_admin', as: 'kit_auth_admin' do
+          define_routes(config)
+    end
+
+    #router.scope options do
+    #  define_routes(config)
+    #end
   end
 
 end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/extend_router.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/extend_router.rb
@@ -2,33 +2,21 @@ class ActiveAdmin::Router
 
   private
 
+  # Allow to override the way routes are mounted through namespace config.
+  #
+  # ### References
+  # - https://github.com/activeadmin/activeadmin/blob/v2.9.0/lib/active_admin/router.rb#L108
   def define_namespace(config)
     options = config.namespace.route_options.dup
-   options.merge!({
-      as:     config.namespace.scope_module,
+    options.merge!({
+      as:     config.namespace.scope_as,
       path:   config.namespace.scope_path,
       module: config.namespace.scope_module,
     })
 
-    puts "DEFINE NAMESPACE - #{ config.namespace }"
-
-=begin
-    router.namespace module: 'admin', path: 'kit_admin', as: 'kit_auth_admin' do
-      router.scope module: 'auth' do
-        router.scope module: 'admin' do
-          define_routes(config)
-        end
-      end
+    router.scope options do
+      define_routes(config)
     end
-=end
-
-    router.scope module: 'admin', path: 'kit_admin', as: 'kit_auth_admin' do
-          define_routes(config)
-    end
-
-    #router.scope options do
-    #  define_routes(config)
-    #end
   end
 
 end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/namespace.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/namespace.rb
@@ -1,9 +1,0 @@
-class ActiveAdmin::Namespace
-
-  def route_prefix
-    puts "ROUTE_PREFIX: #{ root? }|#{ settings.scope_path }|#{ @name }"
-    root? ? nil : (settings.scope_path || @name)
-    @name
-  end
-
-end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/namespace.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/namespace.rb
@@ -1,7 +1,9 @@
 class ActiveAdmin::Namespace
 
   def route_prefix
+    puts "ROUTE_PREFIX: #{ root? }|#{ settings.scope_path }|#{ @name }"
     root? ? nil : (settings.scope_path || @name)
+    @name
   end
 
 end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/resource_controllers.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/resource_controllers.rb
@@ -1,5 +1,9 @@
 module ActiveAdmin::Resource::Controllers
 
+  # Add extra namespace config option to resolve the controller namespace.
+  #
+  # ### References
+  # - https://github.com/activeadmin/activeadmin/blob/v2.9.0/lib/active_admin/resource/controllers.rb#L8
   def controller_name
     module_path = namespace.settings.controllers_path || namespace.module_name
     [module_path, resource_name.plural.camelize + "Controller"].compact.join('::')

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/route_builder.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/route_builder.rb
@@ -1,7 +1,0 @@
-class ActiveAdmin::Resource::Routes::RouteBuilder
-
-  def routes
-    resource.namespace.settings.url_helpers || super
-  end
-
-end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/route_builder.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/route_builder.rb
@@ -1,7 +1,7 @@
 class ActiveAdmin::Resource::Routes::RouteBuilder
 
   def routes
-    resource.namespace.settings.url_helpers
+    resource.namespace.settings.url_helpers || super
   end
 
 end

--- a/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/routes_helpers.rb
+++ b/libraries/kit-active_admin/lib/kit/active_admin/overrides/engines/routes_helpers.rb
@@ -1,0 +1,104 @@
+# Path related.
+#
+# Since we mount the admin directly in the application container, the top level routes are not available in the engine.
+# There might be a more idiomatic way to handle this by making them available somehow?
+#
+# Below are various overwrite to make sure:
+#   - `url_for` is called on `main_app` and not on the engine context.
+#   - when `link_to` is used, it calls the right `url_for`
+
+# See also: `app/helpers/active_admin/views_helper.rb`
+
+# Override `url_for` when it is called directly --------------------------------
+proxy = proc do
+  def url_for(*args, **kwargs)
+    main_app.url_for(*args, **kwargs)
+  end
+end
+
+list = [
+  ActiveAdmin::Component,
+  ActiveAdmin::Views::TableFor,
+  #ActiveAdmin::Views::MenuItem,
+]
+
+list.each do |el|
+  el.class_eval &proxy
+end
+
+# ------------------------------------------------------------------------------
+
+# ### References
+# - https://github.com/activeadmin/activeadmin/blob/v2.9.0/lib/active_admin/namespace.rb#L106
+class ActiveAdmin::Namespace
+
+  # Add namespace config "route_prefix" when defined.
+  def route_prefix
+    segments = []
+
+    if settings.route_prefix
+      segments << settings.route_prefix
+    end
+
+    if !root?
+      segments << (settings.scope_path || @name)
+    end
+
+    segments.empty? ? nil : segments.join('_')
+  end
+
+end
+
+# ------------------------------------------------------------------------------
+
+# ### References
+# - https://github.com/activeadmin/inherited_resources/blob/v1.13.0/lib/inherited_resources/url_helpers.rb#L237
+module InheritedResources::UrlHelpers
+
+  protected
+
+  def define_helper_method(prefix, name, suffix, segments)
+    method_name = [prefix, name, suffix].compact.join('_')
+    params_method_name = ['', prefix, name, :params].compact.join('_')
+    segments_method = [prefix, segments, suffix].compact.join('_')
+
+    undef_method method_name if method_defined? method_name
+
+    define_method method_name do |*given_args|
+      given_args = send params_method_name, *given_args
+      # NOTE: this is the change
+      if segments_method.end_with?('_path') || segment_method.end_with?('_route')
+        main_app.send(segments_method, *given_args)
+      else
+        send segments_method, *given_args
+      end
+    end
+    protected method_name
+  end
+
+end
+
+# ------------------------------------------------------------------------------
+
+class Kaminari::Helpers::Tag
+
+  def page_url_for(page)
+    params = params_for(page)
+    params[:only_path] = true
+    # NOTE: the following line is the change
+    @template.main_app.url_for params
+  end
+
+end
+
+# ------------------------------------------------------------------------------
+
+=begin
+class ActiveAdmin::Resource::Routes::RouteBuilder
+
+  def routes
+    resource.namespace.settings.url_helpers || super
+  end
+
+end
+=end

--- a/libraries/kit-domain/app/models/kit/domain/models/concerns/read_record.rb
+++ b/libraries/kit-domain/app/models/kit/domain/models/concerns/read_record.rb
@@ -43,4 +43,14 @@ module Kit::Domain::Models::Concerns::ReadRecord
     self
   end
 
+  # Ex: User#1
+  def model_log_name
+    "#{ self.class.model_name.element.camelize }##{ self.id }"
+  end
+
+  # Ex: User#1|user@rubykit.org
+  def model_verbose_name
+    "#{ self.class.model_name.element.camelize }##{ self.id }"
+  end
+
 end

--- a/libraries/kit-domain/app/models/kit/domain/models/concerns/write_record.rb
+++ b/libraries/kit-domain/app/models/kit/domain/models/concerns/write_record.rb
@@ -41,4 +41,14 @@ module Kit::Domain::Models::Concerns::WriteRecord
     self
   end
 
+  # Ex: User#1
+  def model_log_name
+    "#{ self.class.model_name.element.camelize }##{ self.id }"
+  end
+
+  # Ex: User#1|user@rubykit.org
+  def model_verbose_name
+    "#{ self.class.model_name.element.camelize }##{ self.id }"
+  end
+
 end

--- a/libraries/kit-domain/lib/kit/domain.rb
+++ b/libraries/kit-domain/lib/kit/domain.rb
@@ -4,11 +4,11 @@ end
 # Shared logic to create Domains.
 module Kit::Domain
 
-  def self.config_domain(namespace:, context:, file:)
+  def self.config_domain(namespace:, context:, path:)
     initializer_name = "#{ namespace.name.underscore.gsub('/', '_') }_engine"
     context.initializer initializer_name do
       if defined?(::ActiveAdmin)
-        ::ActiveAdmin.application.load_paths += Dir[File.expand_path('../../../app/admin', file)]
+        ::ActiveAdmin.application.load_paths += Dir[File.expand_path('../../../app/admin', path)]
       end
     end
   end

--- a/libraries/kit-engine/lib/kit/engine.rb
+++ b/libraries/kit-engine/lib/kit/engine.rb
@@ -6,14 +6,13 @@ end
 # Shared logic to create Engines.
 module Kit::Engine
 
-  def self.config_engine(namespace:, context:, file:)
+  def self.config_engine(namespace:, context:, path:)
     context.isolate_namespace namespace
 
-    # NOTE: Not sure why the number of .. must be different between the 2 !
-    context.config.assets.paths     << File.expand_path('../../../../app/components', file)
-    context.config.eager_load_paths << File.expand_path('../../../app/controllers',   file)
+    context.config.assets.paths     << File.expand_path('../../../app/components', path)
+    context.config.eager_load_paths << File.expand_path('../../../app/controllers',   path)
 
-    engine_public_path = File.expand_path('../../../../public', file)
+    engine_public_path = File.expand_path('../../../public', path)
     if File.directory?(engine_public_path)
       context.initializer 'static assets' do |app|
         app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, engine_public_path)

--- a/libraries/kit-router/lib/kit/router/engine.rb
+++ b/libraries/kit-router/lib/kit/router/engine.rb
@@ -6,7 +6,7 @@ class Kit::Router::Engine < ::Rails::Engine
   Kit::Engine.config_engine(
     context:   self,
     namespace: Kit::Router,
-    file:      __FILE__,
+    path:      __dir__,
   )
 
   initializer 'kit-router.view_helpers' do


### PR DESCRIPTION
Fixes usage of ActiveAdmin in Kit::Auth.

Routes are now setup in the application container, and not in the domain itself.
Contains various hacks to make it work, not super happy about it.